### PR TITLE
disable arm64 assembler and update CI to Go 1.16

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x]
     steps:
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v1
@@ -29,7 +29,7 @@ jobs:
       env:
         GO111MODULE: on
       run: |
-         curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.20.0
+         curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.33.0
          $(go env GOPATH)/bin/golangci-lint run --config ./.golangci.yml
          go vet ./...
   test:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.15.x]
+        go-version: [1.16.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}

--- a/highwayhash_arm64.go
+++ b/highwayhash_arm64.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a license that can be
 // found in the LICENSE file.
 
+//+build ignore
+
 //+build !noasm,!appengine
 
 package highwayhash

--- a/highwayhash_arm64.s
+++ b/highwayhash_arm64.s
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+//+build ignore
+
 //+build !noasm,!appengine
 
 // Use github.com/minio/asm2plan9s on this file to assemble ARM instructions to

--- a/highwayhash_ref.go
+++ b/highwayhash_ref.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a license that can be
 // found in the LICENSE file.
 
-// +build noasm !amd64,!arm64,!ppc64le
+// +build noasm !amd64,!ppc64le
 
 package highwayhash
 


### PR DESCRIPTION
This commit disables the arm64 asm implementation since
it is broken and produces incorrect results on Go 1.16.

Further, this commit updates CI to the Go 1.16 and 1.15.
Once, CI tests for arm64 pass again we can enable it.