### PR TITLE
Improve Go speed

### DIFF
--- a/highwayhash_generic.go
+++ b/highwayhash_generic.go
@@ -46,40 +46,113 @@ func initializeGeneric(state *[16]uint64, k []byte) {
 }
 
 func updateGeneric(state *[16]uint64, msg []byte) {
-	for len(msg) > 0 {
-		// add message
-		state[v1+0] += binary.LittleEndian.Uint64(msg)
-		state[v1+1] += binary.LittleEndian.Uint64(msg[8:])
-		state[v1+2] += binary.LittleEndian.Uint64(msg[16:])
-		state[v1+3] += binary.LittleEndian.Uint64(msg[24:])
+	for len(msg) >= 32 {
+		m := msg[:32]
 
-		// v1 += mul0
-		state[v1+0] += state[mul0+0]
-		state[v1+1] += state[mul0+1]
-		state[v1+2] += state[mul0+2]
-		state[v1+3] += state[mul0+3]
-
+		// add message + mul0
+		// Interleave operations to hide multiplication
+		state[v1+0] += binary.LittleEndian.Uint64(m) + state[mul0+0]
 		state[mul0+0] ^= uint64(uint32(state[v1+0])) * (state[v0+0] >> 32)
-		state[mul0+1] ^= uint64(uint32(state[v1+1])) * (state[v0+1] >> 32)
-		state[mul0+2] ^= uint64(uint32(state[v1+2])) * (state[v0+2] >> 32)
-		state[mul0+3] ^= uint64(uint32(state[v1+3])) * (state[v0+3] >> 32)
-
-		// v0 += mul1
 		state[v0+0] += state[mul1+0]
-		state[v0+1] += state[mul1+1]
-		state[v0+2] += state[mul1+2]
-		state[v0+3] += state[mul1+3]
-
 		state[mul1+0] ^= uint64(uint32(state[v0+0])) * (state[v1+0] >> 32)
+
+		state[v1+1] += binary.LittleEndian.Uint64(m[8:]) + state[mul0+1]
+		state[mul0+1] ^= uint64(uint32(state[v1+1])) * (state[v0+1] >> 32)
+		state[v0+1] += state[mul1+1]
 		state[mul1+1] ^= uint64(uint32(state[v0+1])) * (state[v1+1] >> 32)
+
+		state[v1+2] += binary.LittleEndian.Uint64(m[16:]) + state[mul0+2]
+		state[mul0+2] ^= uint64(uint32(state[v1+2])) * (state[v0+2] >> 32)
+		state[v0+2] += state[mul1+2]
 		state[mul1+2] ^= uint64(uint32(state[v0+2])) * (state[v1+2] >> 32)
+
+		state[v1+3] += binary.LittleEndian.Uint64(m[24:]) + state[mul0+3]
+		state[mul0+3] ^= uint64(uint32(state[v1+3])) * (state[v0+3] >> 32)
+		state[v0+3] += state[mul1+3]
 		state[mul1+3] ^= uint64(uint32(state[v0+3])) * (state[v1+3] >> 32)
 
-		zipperMerge(state[v1+0], state[v1+1], &state[v0+0], &state[v0+1])
-		zipperMerge(state[v1+2], state[v1+3], &state[v0+2], &state[v0+3])
+		// inlined: zipperMerge(state[v1+0], state[v1+1], &state[v0+0], &state[v0+1])
+		{
+			val0 := state[v1+0]
+			val1 := state[v1+1]
+			res := val0 & (0xff << (2 * 8))
+			res2 := (val0 & (0xff << (7 * 8))) + (val1 & (0xff << (2 * 8)))
+			res += (val1 & (0xff << (7 * 8))) >> 8
+			res2 += (val0 & (0xff << (6 * 8))) >> 8
+			res += ((val0 & (0xff << (5 * 8))) + (val1 & (0xff << (6 * 8)))) >> 16
+			res2 += (val1 & (0xff << (5 * 8))) >> 16
+			res += ((val0 & (0xff << (3 * 8))) + (val1 & (0xff << (4 * 8)))) >> 24
+			res2 += ((val1 & (0xff << (3 * 8))) + (val0 & (0xff << (4 * 8)))) >> 24
+			res += (val0 & (0xff << (1 * 8))) << 32
+			res2 += (val1 & 0xff) << 48
+			res += val0 << 56
+			res2 += (val1 & (0xff << (1 * 8))) << 24
 
-		zipperMerge(state[v0+0], state[v0+1], &state[v1+0], &state[v1+1])
-		zipperMerge(state[v0+2], state[v0+3], &state[v1+2], &state[v1+3])
+			state[v0+0] += res
+			state[v0+1] += res2
+		}
+		// zipperMerge(state[v1+2], state[v1+3], &state[v0+2], &state[v0+3])
+		{
+			val0 := state[v1+2]
+			val1 := state[v1+3]
+			res := val0 & (0xff << (2 * 8))
+			res2 := (val0 & (0xff << (7 * 8))) + (val1 & (0xff << (2 * 8)))
+			res += (val1 & (0xff << (7 * 8))) >> 8
+			res2 += (val0 & (0xff << (6 * 8))) >> 8
+			res += ((val0 & (0xff << (5 * 8))) + (val1 & (0xff << (6 * 8)))) >> 16
+			res2 += (val1 & (0xff << (5 * 8))) >> 16
+			res += ((val0 & (0xff << (3 * 8))) + (val1 & (0xff << (4 * 8)))) >> 24
+			res2 += ((val1 & (0xff << (3 * 8))) + (val0 & (0xff << (4 * 8)))) >> 24
+			res += (val0 & (0xff << (1 * 8))) << 32
+			res2 += (val1 & 0xff) << 48
+			res += val0 << 56
+			res2 += (val1 & (0xff << (1 * 8))) << 24
+
+			state[v0+2] += res
+			state[v0+3] += res2
+		}
+
+		// inlined: zipperMerge(state[v0+0], state[v0+1], &state[v1+0], &state[v1+1])
+		{
+			val0 := state[v0+0]
+			val1 := state[v0+1]
+			res := val0 & (0xff << (2 * 8))
+			res2 := (val0 & (0xff << (7 * 8))) + (val1 & (0xff << (2 * 8)))
+			res += (val1 & (0xff << (7 * 8))) >> 8
+			res2 += (val0 & (0xff << (6 * 8))) >> 8
+			res += ((val0 & (0xff << (5 * 8))) + (val1 & (0xff << (6 * 8)))) >> 16
+			res2 += (val1 & (0xff << (5 * 8))) >> 16
+			res += ((val0 & (0xff << (3 * 8))) + (val1 & (0xff << (4 * 8)))) >> 24
+			res2 += ((val1 & (0xff << (3 * 8))) + (val0 & (0xff << (4 * 8)))) >> 24
+			res += (val0 & (0xff << (1 * 8))) << 32
+			res2 += (val1 & 0xff) << 48
+			res += val0 << 56
+			res2 += (val1 & (0xff << (1 * 8))) << 24
+
+			state[v1+0] += res
+			state[v1+1] += res2
+		}
+
+		//inlined: zipperMerge(state[v0+2], state[v0+3], &state[v1+2], &state[v1+3])
+		{
+			val0 := state[v0+2]
+			val1 := state[v0+3]
+			res := val0 & (0xff << (2 * 8))
+			res2 := (val0 & (0xff << (7 * 8))) + (val1 & (0xff << (2 * 8)))
+			res += (val1 & (0xff << (7 * 8))) >> 8
+			res2 += (val0 & (0xff << (6 * 8))) >> 8
+			res += ((val0 & (0xff << (5 * 8))) + (val1 & (0xff << (6 * 8)))) >> 16
+			res2 += (val1 & (0xff << (5 * 8))) >> 16
+			res += ((val0 & (0xff << (3 * 8))) + (val1 & (0xff << (4 * 8)))) >> 24
+			res2 += ((val1 & (0xff << (3 * 8))) + (val0 & (0xff << (4 * 8)))) >> 24
+			res += (val0 & (0xff << (1 * 8))) << 32
+			res2 += (val1 & 0xff) << 48
+			res += val0 << 56
+			res2 += (val1 & (0xff << (1 * 8))) << 24
+
+			state[v1+2] += res
+			state[v1+3] += res2
+		}
 		msg = msg[32:]
 	}
 }
@@ -125,23 +198,125 @@ func finalizeGeneric(out []byte, state *[16]uint64) {
 }
 
 func zipperMerge(v0, v1 uint64, d0, d1 *uint64) {
-	m0 := v0 & (0xFF << (2 * 8))
-	m1 := (v1 & (0xFF << (7 * 8))) >> 8
-	m2 := ((v0 & (0xFF << (5 * 8))) + (v1 & (0xFF << (6 * 8)))) >> 16
-	m3 := ((v0 & (0xFF << (3 * 8))) + (v1 & (0xFF << (4 * 8)))) >> 24
-	m4 := (v0 & (0xFF << (1 * 8))) << 32
-	m5 := v0 << 56
+	// Experiments on variations left for future reference...
+	if true {
+		// fastest. original interleaved...
+		res := v0 & (0xff << (2 * 8))
+		res2 := (v0 & (0xff << (7 * 8))) + (v1 & (0xff << (2 * 8)))
+		res += (v1 & (0xff << (7 * 8))) >> 8
+		res2 += (v0 & (0xff << (6 * 8))) >> 8
+		res += ((v0 & (0xff << (5 * 8))) + (v1 & (0xff << (6 * 8)))) >> 16
+		res2 += (v1 & (0xff << (5 * 8))) >> 16
+		res += ((v0 & (0xff << (3 * 8))) + (v1 & (0xff << (4 * 8)))) >> 24
+		res2 += ((v1 & (0xff << (3 * 8))) + (v0 & (0xff << (4 * 8)))) >> 24
+		res += (v0 & (0xff << (1 * 8))) << 32
+		res2 += (v1 & 0xff) << 48
+		res += v0 << 56
+		res2 += (v1 & (0xff << (1 * 8))) << 24
 
-	*d0 += m0 + m1 + m2 + m3 + m4 + m5
+		*d0 += res
+		*d1 += res2
+	} else if false {
+		// Reading bytes and combining into uint64
+		var v0b [8]byte
+		binary.LittleEndian.PutUint64(v0b[:], v0)
+		var v1b [8]byte
+		binary.LittleEndian.PutUint64(v1b[:], v1)
+		var res, res2 uint64
 
-	m0 = (v0 & (0xFF << (7 * 8))) + (v1 & (0xFF << (2 * 8)))
-	m1 = (v0 & (0xFF << (6 * 8))) >> 8
-	m2 = (v1 & (0xFF << (5 * 8))) >> 16
-	m3 = ((v1 & (0xFF << (3 * 8))) + (v0 & (0xFF << (4 * 8)))) >> 24
-	m4 = (v1 & 0xFF) << 48
-	m5 = (v1 & (0xFF << (1 * 8))) << 24
+		res = uint64(v0b[0]) << (7 * 8)
+		res2 = uint64(v1b[0]) << (6 * 8)
+		res |= uint64(v0b[1]) << (5 * 8)
+		res2 |= uint64(v1b[1]) << (4 * 8)
+		res |= uint64(v0b[2]) << (2 * 8)
+		res2 |= uint64(v1b[2]) << (2 * 8)
+		res |= uint64(v0b[3])
+		res2 |= uint64(v0b[4]) << (1 * 8)
+		res |= uint64(v0b[5]) << (3 * 8)
+		res2 |= uint64(v0b[6]) << (5 * 8)
+		res |= uint64(v1b[4]) << (1 * 8)
+		res2 |= uint64(v0b[7]) << (7 * 8)
+		res |= uint64(v1b[6]) << (4 * 8)
+		res2 |= uint64(v1b[3])
+		res |= uint64(v1b[7]) << (6 * 8)
+		res2 |= uint64(v1b[5]) << (3 * 8)
 
-	*d1 += m3 + m2 + m5 + m1 + m4 + m0
+		*d0 += res
+		*d1 += res2
+
+	} else if false {
+		// bytes to bytes shuffle
+		var v0b [8]byte
+		binary.LittleEndian.PutUint64(v0b[:], v0)
+		var v1b [8]byte
+		binary.LittleEndian.PutUint64(v1b[:], v1)
+		var res [8]byte
+
+		//res += ((v0 & (0xff << (3 * 8))) + (v1 & (0xff << (4 * 8)))) >> 24
+		res[0] = v0b[3]
+		res[1] = v1b[4]
+
+		// res := v0 & (0xff << (2 * 8))
+		res[2] = v0b[2]
+
+		//res += ((v0 & (0xff << (5 * 8))) + (v1 & (0xff << (6 * 8)))) >> 16
+		res[3] = v0b[5]
+		res[4] = v1b[6]
+
+		//res += (v0 & (0xff << (1 * 8))) << 32
+		res[5] = v0b[1]
+
+		//res += (v1 & (0xff << (7 * 8))) >> 8
+		res[6] += v1b[7]
+
+		//res += v0 << 56
+		res[7] = v0b[0]
+		v0 = binary.LittleEndian.Uint64(res[:])
+		*d0 += v0
+
+		//res += ((v1 & (0xff << (3 * 8))) + (v0 & (0xff << (4 * 8)))) >> 24
+		res[0] = v1b[3]
+		res[1] = v0b[4]
+
+		res[2] = v1b[2]
+
+		// res += (v1 & (0xff << (5 * 8))) >> 16
+		res[3] = v1b[5]
+
+		//res += (v1 & (0xff << (1 * 8))) << 24
+		res[4] = v1b[1]
+
+		// res += (v0 & (0xff << (6 * 8))) >> 8
+		res[5] = v0b[6]
+
+		//res := (v0 & (0xff << (7 * 8))) + (v1 & (0xff << (2 * 8)))
+		res[7] = v0b[7]
+
+		//res += (v1 & 0xff) << 48
+		res[6] = v1b[0]
+
+		v0 = binary.LittleEndian.Uint64(res[:])
+		*d1 += v0
+	} else {
+		// original.
+		res := v0 & (0xff << (2 * 8))
+		res += (v1 & (0xff << (7 * 8))) >> 8
+		res += ((v0 & (0xff << (5 * 8))) + (v1 & (0xff << (6 * 8)))) >> 16
+		res += ((v0 & (0xff << (3 * 8))) + (v1 & (0xff << (4 * 8)))) >> 24
+		res += (v0 & (0xff << (1 * 8))) << 32
+		res += v0 << 56
+
+		*d0 += res
+
+		res = (v0 & (0xff << (7 * 8))) + (v1 & (0xff << (2 * 8)))
+		res += (v0 & (0xff << (6 * 8))) >> 8
+		res += (v1 & (0xff << (5 * 8))) >> 16
+		res += ((v1 & (0xff << (3 * 8))) + (v0 & (0xff << (4 * 8)))) >> 24
+		res += (v1 & 0xff) << 48
+		res += (v1 & (0xff << (1 * 8))) << 24
+
+		*d1 += res
+	}
 }
 
 // reduce v = [v0, v1, v2, v3] mod the irreducible polynomial x^128 + x^2 + x


### PR DESCRIPTION
Faster Go code by interleaving operations and inling zipper code.

```
benchmark                    old ns/op     new ns/op     delta
BenchmarkWrite_8-32          9.24          8.66          -6.28%
BenchmarkWrite_16-32         15.3          13.8          -9.78%
BenchmarkWrite_64-32         44.6          38.9          -12.84%
BenchmarkWrite_1K-32         668           564           -15.66%
BenchmarkWrite_8K-32         5252          4495          -14.41%
BenchmarkSum64_8-32          146           128           -12.05%
BenchmarkSum64_16-32         148           132           -10.74%
BenchmarkSum64_64-32         154           136           -12.18%
BenchmarkSum64_1K-32         776           658           -15.30%
BenchmarkSum64_8K-32         5376          4616          -14.14%
BenchmarkSum256_8-32         300           263           -12.40%
BenchmarkSum256_16-32        304           266           -12.47%
BenchmarkSum256_64-32        320           263           -17.88%
BenchmarkSum256_1K-32        939           794           -15.47%
BenchmarkSum256_8K-32        5548          4712          -15.07%
BenchmarkSum256_1M-32        681705        575480        -15.58%
BenchmarkSum256_5M-32        3409493       2876752       -15.63%
BenchmarkSum256_10M-32       6808693       5759719       -15.41%
BenchmarkSum256_25M-32       17062713      14422506      -15.47%
BenchmarkParallel_1M-32      44241         37559         -15.10%
BenchmarkParallel_5M-32      220972        188019        -14.91%
BenchmarkParallel_10M-32     454317        377080        -17.00%
BenchmarkParallel_25M-32     1111869       947157        -14.81%

benchmark                    old MB/s     new MB/s     speedup
BenchmarkWrite_8-32          866.18       924.18       1.07x
BenchmarkWrite_16-32         1043.84      1157.03      1.11x
BenchmarkWrite_64-32         1434.39      1645.50      1.15x
BenchmarkWrite_1K-32         1532.63      1817.21      1.19x
BenchmarkWrite_8K-32         1559.83      1822.28      1.17x
BenchmarkSum64_8-32          54.81        62.31        1.14x
BenchmarkSum64_16-32         108.03       121.03       1.12x
BenchmarkSum64_64-32         414.85       472.26       1.14x
BenchmarkSum64_1K-32         1319.03      1557.48      1.18x
BenchmarkSum64_8K-32         1523.91      1774.69      1.16x
BenchmarkSum256_8-32         26.66        30.43        1.14x
BenchmarkSum256_16-32        52.65        60.16        1.14x
BenchmarkSum256_64-32        199.76       243.26       1.22x
BenchmarkSum256_1K-32        1090.84      1290.44      1.18x
BenchmarkSum256_8K-32        1476.49      1738.54      1.18x
BenchmarkSum256_1M-32        1538.17      1822.09      1.18x
BenchmarkSum256_5M-32        1537.73      1822.50      1.19x
BenchmarkSum256_10M-32       1540.05      1820.53      1.18x
BenchmarkSum256_25M-32       1536.36      1817.60      1.18x
BenchmarkParallel_1M-32      23701.69     27917.92     1.18x
BenchmarkParallel_5M-32      23726.40     27884.84     1.18x
BenchmarkParallel_10M-32     23080.26     27807.81     1.20x
BenchmarkParallel_25M-32     23576.87     27676.93     1.17x
```